### PR TITLE
Issue 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 * `hi [-u <user>] [[<date>] <from time>[-<to time>]]` - 勤務開始時刻を記録します。
 * `bye [-u <user>] [[<date>] [<from time>-]<to time>]` - 勤務終了時刻を記録します。
+* `bye [-u <user>] <date>` - 勤務記録を削除します。
 * `list [-u <user>] [<month>]` - 勤務表を表示します。
 
 ### Formatting
@@ -35,6 +36,7 @@
 * `bye -u rotsuya` - rotsuyaが会社を出たので代わりに記録してあげる。
 * `list 201412` - 2014年12月の勤務表を見たい。
 * `list -u rotsuya 201412` - rotsuyaの2014年12月の勤務表を見たい。
+* `rm 12/24` - 間違えて登録した12月24日の記録を削除する。
 
 ## Usage:
 

--- a/scripts/otsubot.js
+++ b/scripts/otsubot.js
@@ -310,8 +310,7 @@ module.exports = function (robot) {
 
     function remove(user, date) {
         var key = [user, date];
-        var value = robot.brain.get(JSON.stringify(key)) || [];
-        robot.brain.remove(JSON.stringify(key), value);
+        robot.brain.remove(JSON.stringify(key));
     }
 
     function respond(command, user, date, from, to, msg) {


### PR DESCRIPTION
Add remove command into otsubot. Any user can remove a record from a specified user’s timecard by this command.

Refs #3 

Results of Manual tests in localhost are as follows:
```
otsubot> hi 10/16 9
otsubot> おはようございます。Shellの2018/10/16の勤務時間は09:00~だね。

otsubot> bye 10/16 18
otsubot> お疲れさま。Shellの2018/10/16の勤務時間は~18:00だね。

otsubot> hi 10/17 10
otsubot> おはようございます。Shellの2018/10/17の勤務時間は10:00~だね。

otsubot> bye 10/17 20
otsubot> 乙。Shellの2018/10/17の勤務時間は~20:00だね。

otsubot> list
otsubot> Shellの10月の勤務表だね。
```date       | recorded      | calculated    | overtime
2018/10/16 | 09:00 | 18:00 | 09:00 | 18:00 | 00:30
2018/10/17 | 10:00 | 20:00 | 10:00 | 20:00 | 01:30
sum        |       |       |       |       | 02:00```

otsubot> rm 1017
otsubot> Shellの2018/10/17の勤務記録を削除だね。

otsubot> list
otsubot> Shellの10月の勤務表だね。
```date       | recorded      | calculated    | overtime
2018/10/16 | 09:00 | 18:00 | 09:00 | 18:00 | 00:30
sum        |       |       |       |       | 00:30```
```